### PR TITLE
bug/fix-branch-name-in-action

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -2,10 +2,9 @@ name: Android CI
 
 on:
   push:
-    branches: [ "Android_Development" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "Android_Development" ]
-  workflow_dispatch:
+    branches: [ "master" ]
 
 jobs:
   build:


### PR DESCRIPTION
Branch name updated away from `Android_Development` to `master`. Need to use that in the Github action branch target.