### PR TITLE
changed settings page theme mode option to a switch

### DIFF
--- a/app/src/main/java/deakin/gopher/guardian/view/general/Setting.java
+++ b/app/src/main/java/deakin/gopher/guardian/view/general/Setting.java
@@ -21,6 +21,7 @@ public class Setting extends AppCompatActivity implements View.OnClickListener {
   ConstraintLayout settingsAppUpdateButton;
   ConstraintLayout settingsFeedbackButton;
   Switch notificationSwitch;
+  Switch themeSwitch;
 
   @Override
   protected void onCreate(final Bundle savedInstanceState) {
@@ -32,30 +33,37 @@ public class Setting extends AppCompatActivity implements View.OnClickListener {
     settingsAppUpdateButton = findViewById(R.id.settings_app_update_button);
     settingsFeedbackButton = findViewById(R.id.settings_feedback_button);
 
-    settingsThemeButton.setOnClickListener(this);
-    settingsNotificationButton.setOnClickListener(this);
+//    settingsThemeButton.setOnClickListener(this);
+//    settingsNotificationButton.setOnClickListener(this);
     settingsAppUpdateButton.setOnClickListener(this);
     settingsFeedbackButton.setOnClickListener(this);
 
     final ConstraintLayout settingsThemeButton = findViewById(R.id.settings_theme_button);
-    settingsThemeButton.setOnClickListener(
-        v -> {
-          final SharedPreferences sharedPreferences =
-              getSharedPreferences("settings", MODE_PRIVATE);
-          final boolean currentNightMode = sharedPreferences.getBoolean("night_mode", false);
-          if (currentNightMode) {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
-            sharedPreferences.edit().putBoolean("night_mode", false).apply();
-          } else {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
-            sharedPreferences.edit().putBoolean("night_mode", true).apply();
-          }
-          recreate();
-        });
+
+    // Below code was from old theme change method, can be deleted if new Switch is accepted
+
+//    settingsThemeButton.setOnClickListener(
+//        v -> {
+//          final SharedPreferences sharedPreferences =
+//              getSharedPreferences("settings", MODE_PRIVATE);
+//          final boolean currentNightMode = sharedPreferences.getBoolean("night_mode", false);
+//          if (currentNightMode) {
+//            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+//            sharedPreferences.edit().putBoolean("night_mode", false).apply();
+//          } else {
+//            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+//            sharedPreferences.edit().putBoolean("night_mode", true).apply();
+//          }
+//          recreate();
+//        });
 
     notificationSwitch = findViewById(R.id.notification_switch);
     notificationSwitch.setOnCheckedChangeListener(
         (buttonView, isChecked) -> handleNotificationSwitch(isChecked));
+
+    themeSwitch = findViewById(R.id.theme_switch);
+    themeSwitch.setOnCheckedChangeListener(
+            (buttonView, isChecked) -> handleThemeSwitch(isChecked));
   }
 
   @Override
@@ -73,6 +81,20 @@ public class Setting extends AppCompatActivity implements View.OnClickListener {
       showToast("Notifications turned off");
     }
   }
+
+  private void handleThemeSwitch(final boolean isChecked) {
+    final SharedPreferences sharedPreferences =
+            getSharedPreferences("settings", MODE_PRIVATE);
+//    final boolean currentNightMode = sharedPreferences.getBoolean("night_mode", false);
+
+      if (isChecked) {
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+        sharedPreferences.edit().putBoolean("night_mode", true).apply();
+      } else {
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+        sharedPreferences.edit().putBoolean("night_mode", false).apply();
+      }
+    }
 
   private void showNotification() {
     if (Build.VERSION_CODES.O <= Build.VERSION.SDK_INT) {

--- a/app/src/main/java/deakin/gopher/guardian/view/general/Setting.java
+++ b/app/src/main/java/deakin/gopher/guardian/view/general/Setting.java
@@ -33,37 +33,17 @@ public class Setting extends AppCompatActivity implements View.OnClickListener {
     settingsAppUpdateButton = findViewById(R.id.settings_app_update_button);
     settingsFeedbackButton = findViewById(R.id.settings_feedback_button);
 
-//    settingsThemeButton.setOnClickListener(this);
-//    settingsNotificationButton.setOnClickListener(this);
     settingsAppUpdateButton.setOnClickListener(this);
     settingsFeedbackButton.setOnClickListener(this);
 
     final ConstraintLayout settingsThemeButton = findViewById(R.id.settings_theme_button);
-
-    // Below code was from old theme change method, can be deleted if new Switch is accepted
-
-//    settingsThemeButton.setOnClickListener(
-//        v -> {
-//          final SharedPreferences sharedPreferences =
-//              getSharedPreferences("settings", MODE_PRIVATE);
-//          final boolean currentNightMode = sharedPreferences.getBoolean("night_mode", false);
-//          if (currentNightMode) {
-//            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
-//            sharedPreferences.edit().putBoolean("night_mode", false).apply();
-//          } else {
-//            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
-//            sharedPreferences.edit().putBoolean("night_mode", true).apply();
-//          }
-//          recreate();
-//        });
 
     notificationSwitch = findViewById(R.id.notification_switch);
     notificationSwitch.setOnCheckedChangeListener(
         (buttonView, isChecked) -> handleNotificationSwitch(isChecked));
 
     themeSwitch = findViewById(R.id.theme_switch);
-    themeSwitch.setOnCheckedChangeListener(
-            (buttonView, isChecked) -> handleThemeSwitch(isChecked));
+    themeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> handleThemeSwitch(isChecked));
   }
 
   @Override
@@ -83,18 +63,15 @@ public class Setting extends AppCompatActivity implements View.OnClickListener {
   }
 
   private void handleThemeSwitch(final boolean isChecked) {
-    final SharedPreferences sharedPreferences =
-            getSharedPreferences("settings", MODE_PRIVATE);
-//    final boolean currentNightMode = sharedPreferences.getBoolean("night_mode", false);
-
-      if (isChecked) {
-        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
-        sharedPreferences.edit().putBoolean("night_mode", true).apply();
-      } else {
-        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
-        sharedPreferences.edit().putBoolean("night_mode", false).apply();
-      }
+    final SharedPreferences sharedPreferences = getSharedPreferences("settings", MODE_PRIVATE);
+    if (isChecked) {
+      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+      sharedPreferences.edit().putBoolean("night_mode", true).apply();
+    } else {
+      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+      sharedPreferences.edit().putBoolean("night_mode", false).apply();
     }
+  }
 
   private void showNotification() {
     if (Build.VERSION_CODES.O <= Build.VERSION.SDK_INT) {

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -62,56 +62,43 @@
     </androidx.cardview.widget.CardView>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/settings_theme_button"
-            android:layout_width="match_parent"
-            android:layout_height="50dp"
-            android:layout_marginStart="15dp"
-            android:layout_marginTop="50dp"
+        android:id="@+id/settings_theme_button"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:layout_marginLeft="15dp"
+        android:layout_marginTop="50dp"
+        android:layout_marginRight="15dp"
+        android:background="@drawable/settings_button_background"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/settings_header_card_view">
+
+
+        <TextView
+            android:id="@+id/theme_button_title"
+            android:layout_width="wrap_content"
+            android:layout_height="20sp"
+            android:layout_marginStart="25dp"
+            android:fontFamily="@font/poppins"
+            android:text="@string/night_mode"
+            android:textColor="#FFFFFF"
+            android:textFontWeight="400"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.533" />
+
+        <Switch
+            android:id="@+id/theme_switch"
+            android:layout_width="46dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="204dp"
+            android:layout_marginTop="12dp"
             android:layout_marginEnd="15dp"
-            android:background="@drawable/settings_button_background"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/settings_header_card_view">
-
-
-        <TextView
-                android:id="@+id/theme_button_title"
-                android:layout_width="wrap_content"
-                android:layout_height="20sp"
-                android:layout_marginStart="25dp"
-                android:fontFamily="@font/poppins"
-                android:text="@string/theme_mode"
-                android:textColor="#FFFFFF"
-                android:textFontWeight="400"
-                android:textSize="16sp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
-                android:id="@+id/theme_button_arrow"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="15dp"
-                android:contentDescription="TODO"
-                android:src="@drawable/settings_arrow"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-                android:id="@+id/theme_button_subtitle"
-                android:layout_width="wrap_content"
-                android:layout_height="17sp"
-                android:layout_marginEnd="8dp"
-                android:fontFamily="@font/poppins"
-                android:text="@string/change"
-                android:textColor="#FFFFFF"
-                android:textFontWeight="275"
-                android:textSize="13sp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@id/theme_button_arrow"
-                app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/theme_button_title"
+            app:layout_constraintTop_toTopOf="parent" />
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>
@@ -144,37 +131,27 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
         <Switch
-                android:id="@+id/notification_switch"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="15dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
-                android:id="@+id/notification_button_arrow"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="15dp"
-                android:contentDescription="TODO"
-                android:src="@drawable/settings_arrow"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+            android:id="@+id/notification_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="196dp"
+            android:layout_marginEnd="15dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/notification_button_title"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
-                android:id="@+id/notification_button_subtitle"
-                android:layout_width="wrap_content"
-                android:layout_height="18sp"
-                android:layout_marginEnd="8dp"
-                android:fontFamily="@font/poppins"
-                android:textFontWeight="275"
-                android:textIsSelectable="true"
-                android:textSize="13sp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@id/notification_button_arrow"
-                app:layout_constraintTop_toTopOf="parent" />
+            android:id="@+id/notification_button_subtitle"
+            android:layout_width="wrap_content"
+            android:layout_height="18sp"
+            android:fontFamily="@font/poppins"
+            android:textFontWeight="275"
+            android:textIsSelectable="true"
+            android:textSize="13sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:layout_editor_absoluteX="352dp" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -141,17 +141,6 @@
             app:layout_constraintStart_toEndOf="@+id/notification_button_title"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/notification_button_subtitle"
-            android:layout_width="wrap_content"
-            android:layout_height="18sp"
-            android:fontFamily="@font/poppins"
-            android:textFontWeight="275"
-            android:textIsSelectable="true"
-            android:textSize="13sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:layout_editor_absoluteX="352dp" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,7 +216,7 @@
     <string name="back_to_login">Back to Login</string>
     <string name="already_registered_login_here">Already Registered ? Login Here</string>
     <string name="account_creation">Account Creation</string>
-    <string name="theme_mode">Theme Mode</string>
+    <string name="night_mode">Night Mode</string>
     <string name="change">Change</string>
     <string name="app_update">App Update</string>
     <string name="feedback">Feedback</string>


### PR DESCRIPTION
3 files modifies: settings.java, activity_setting.xml, and strings.xml

I modified the code to use a Switch instead, and adjusted the settings.xml layout settings, with the text changed to “Night Mode” (layout\values\strings.xml) as it is commonly called on apps and software. Also removed the arrows from the two top buttons and the setOnClickListener for the two top buttons, as there didn’t seem any point to have the whole button respond when the Switch can be clicked separately as well.