### PR TITLE
Run linter and build concurrently to improve speed

### DIFF
--- a/.github/workflows/android-lint-build.yml
+++ b/.github/workflows/android-lint-build.yml
@@ -2,29 +2,27 @@ name: Android CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
   schedule:
     - cron: "0 7 * * *"
 
 jobs:
-  build:
-
+  lint-build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        gradle-task: [lint, build]
     steps:
       - uses: actions/checkout@v3
       - name: set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "17"
+          distribution: "temurin"
           cache: gradle
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Build with Gradle
-        run: ./gradlew build
-      - name: Android Lint with Gradle
-        run: ./gradlew lint
+      - name: Run gradle tasks
+        run: ./gradlew ${{ matrix.gradle.task }}


### PR DESCRIPTION
Putting the two gradle tasks in a matrix would run linting and building concurrently.