### PR TITLE
Ci skip app build

### DIFF
--- a/.github/workflows/android-lint-build.yml
+++ b/.github/workflows/android-lint-build.yml
@@ -3,8 +3,12 @@ name: Android CI
 on:
   push:
     branches: ["master"]
+    paths:
+      - 'app/**'
   pull_request:
     branches: ["master"]
+    paths:
+      - 'app/**'
   schedule:
     - cron: "0 7 * * *"
 

--- a/.github/workflows/android-lint-build.yml
+++ b/.github/workflows/android-lint-build.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run gradle tasks
-        run: ./gradlew ${{ matrix.gradle.task }}
+        run: ./gradlew ${{ matrix.gradle-task }}


### PR DESCRIPTION
Add a path filter to skip app builds for unrelated changes such as documentation updates.