### PR TITLE
Remove Logout button from Get Started page.

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,22 +25,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView" />
 
-    <Button
-        android:id="@+id/logoutButton"
-        android:layout_width="246dp"
-        android:layout_height="51dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
-        android:backgroundTint="@color/TG_blue"
-        android:text="@string/logout"
-        android:textColor="@color/white"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.496"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/getStartedButton"
-        app:layout_constraintVertical_bias="0.529" />
-
     <TextView
         android:id="@+id/textView"
         android:layout_width="0dp"


### PR DESCRIPTION
## Description

This PR removes the logout button from the Get Started page.

### Todos

- [x] Tested and working locally
- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] Code changes documented
- [x] Requested review from >= 2 devs on the team (one frontend and one backend recommended)

### How to test

1. Launch the Guardian application.
2. Verify that there is no Logout button on the Get Started page.

### Screenshots and/or Gifs

[Insert screenshots and/or gifs showing the graphic representation of the change]

### Associated MS Planner Tasks

- [Task Title](http://ms_planner_task_link.com)
- [Task Title](http://ms_planner_task_link.com)
