### PR TITLE
Update android-build.yml to address Gradle Build

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'corretto'
 
       - name: Run Gradle Build
-        run: ./gradlew build
+        run: gradle build
 
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v4.3.6


### PR DESCRIPTION
Regular issues with pull request failure due to running gradle build failing. Fix from multiple sources online suggests slight alteration to line 23 from './gradlew build' to 'gradle build'.

## Description

[Describe the change that was made in this PR]

### Todos

- [ ] Tested and working locally
- [ ] Code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] Code changes documented
- [ ] Requested review from >= 2 devs on the team (one frontend and one backend recommended)

### How to test

[Add detailed steps to test the changes that have been made]

### Screenshots and/or Gifs

[Insert screenshots and/or gifs showing the graphic representation of the change]

### Associated MS Planner Tasks

- [Task Title](http://ms_planner_task_link.com)
- [Task Title](http://ms_planner_task_link.com)

### Known Issues

[Describe any known issue with this change]
