### PR TITLE
Bug Fix: Onclick of Patient Overview in sidebar

### DIFF
--- a/guardian-admin-dashboard/src/App.jsx
+++ b/guardian-admin-dashboard/src/App.jsx
@@ -37,7 +37,7 @@ export default function App() {
         <Route path="staff-management" element={<StaffManagementPage />} />
         <Route path="org-assignment" element={<OrgAssignmentPage />} />
         <Route path="patients" element={<PatientsPage />} />
-        <Route path="patients/:patientId/overview" element={<PatientOverviewPage />} />
+        <Route path="patient-overview" element={<PatientOverviewPage />} />
         <Route path="nurse-roster" element={<NurseRosterPage />} />
         <Route path="reports" element={<ReportsPage />} />
         <Route path="settings" element={<SettingsPage />} />


### PR DESCRIPTION

## Description

I have tested, and when onclicking of the patient overview the application is getting logged out. 

### Todos

- [✔️ ] Tested and working locally
- [✔️ ] Code follows the style guidelines of this project
- [ ✔️] I have performed a self-review of my code
- [ ✔️] Code changes documented
- [✔️ ] Requested review from >= 2 devs on the team (one frontend and one backend recommended)

### How to test

Login in as admin, click on patient-overview from the sidebar

### Screenshots and/or Gifs

<img width="1867" height="897" alt="image" src="https://github.com/user-attachments/assets/cb62ace3-52e0-4870-ae0b-0ae66e42ab6d" />


### Associated MS Planner Tasks

Bug Fix: Onclick Patient overview - admin dashboard

### Known Issues

[Describe any known issue with this change]
