### PR TITLE
Added nurse roaster admin dashboard UI

### DIFF
--- a/guardian-admin-dashboard/src/pages/NurseRoasterPage.css
+++ b/guardian-admin-dashboard/src/pages/NurseRoasterPage.css
@@ -1,0 +1,315 @@
+.nurse-roaster-page {
+  display: grid;
+  gap: 22px;
+}
+
+.nurse-roaster-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+}
+
+.nurse-roaster-eyebrow {
+  margin: 0 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.nurse-roaster-header h1 {
+  margin: 0;
+  font-size: 2rem;
+  color: var(--primary-dark);
+}
+
+.nurse-roaster-subtitle {
+  margin: 10px 0 0;
+  color: var(--text-muted);
+  max-width: 720px;
+}
+
+.nurse-primary-btn {
+  border: 0;
+  border-radius: 14px;
+  padding: 12px 18px;
+  cursor: pointer;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: linear-gradient(135deg, var(--primary), #3d92bf);
+  color: white;
+  box-shadow: var(--shadow-sm);
+  transition: 0.2s ease;
+}
+
+.nurse-primary-btn:hover {
+  transform: translateY(-1px);
+}
+
+.nurse-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.nurse-summary-card {
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 18px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.nurse-summary-card strong {
+  display: block;
+  font-size: 1.4rem;
+  color: var(--primary-dark);
+}
+
+.nurse-summary-card span {
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.nurse-toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.nurse-search-box {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 340px;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 12px 14px;
+}
+
+.nurse-search-box input {
+  border: 0;
+  outline: none;
+  width: 100%;
+  background: transparent;
+  font: inherit;
+}
+
+.nurse-filter-group {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.nurse-filter-select {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 10px 12px;
+}
+
+.nurse-filter-select select {
+  border: 0;
+  outline: none;
+  background: transparent;
+  font: inherit;
+  color: var(--primary-dark);
+  cursor: pointer;
+}
+
+.nurse-roaster-card {
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.nurse-roaster-card-header {
+  padding: 22px 22px 10px;
+}
+
+.nurse-roaster-card-header h3 {
+  margin: 0;
+  color: var(--primary-dark);
+}
+
+.nurse-roaster-card-header p {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+}
+
+.nurse-roaster-table-wrap {
+  overflow-x: auto;
+}
+
+.nurse-roaster-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.nurse-roaster-table th,
+.nurse-roaster-table td {
+  padding: 16px 18px;
+  text-align: left;
+  border-top: 1px solid #edf3f7;
+  vertical-align: middle;
+}
+
+.nurse-roaster-table th {
+  font-size: 0.9rem;
+  color: var(--primary-dark);
+  background: #f9fcfe;
+  white-space: nowrap;
+}
+
+.nurse-roaster-table td {
+  color: var(--text);
+  font-size: 0.94rem;
+}
+
+.nurse-name-cell {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.nurse-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #dff1fb, #edf7fd);
+  color: var(--primary-dark);
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.nurse-name-cell strong {
+  display: block;
+  color: var(--primary-dark);
+}
+
+.nurse-name-cell span {
+  display: block;
+  margin-top: 3px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.nurse-contact-cell {
+  display: grid;
+  gap: 6px;
+}
+
+.nurse-contact-cell span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.nurse-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 12px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.nurse-status.on-duty {
+  background: rgba(23, 166, 115, 0.14);
+  color: #158b61;
+}
+
+.nurse-status.off-duty {
+  background: rgba(79, 160, 200, 0.14);
+  color: #2f7ca2;
+}
+
+.nurse-status.on-leave {
+  background: rgba(232, 163, 23, 0.14);
+  color: #a57514;
+}
+
+.nurse-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.nurse-icon-btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: white;
+  color: var(--primary-dark);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+.nurse-icon-btn:hover {
+  background: #f8fbfd;
+}
+
+.nurse-empty-state {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 28px !important;
+}
+
+@media (max-width: 1100px) {
+  .nurse-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .nurse-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .nurse-search-box {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .nurse-filter-group {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 720px) {
+  .nurse-roaster-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .nurse-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .nurse-primary-btn {
+    justify-content: center;
+  }
+}

--- a/guardian-admin-dashboard/src/pages/NurseRoasterPage.css
+++ b/guardian-admin-dashboard/src/pages/NurseRoasterPage.css
@@ -57,7 +57,7 @@
 }
 
 .nurse-summary-card {
-  background: white;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 20px;
   padding: 18px;
@@ -90,7 +90,7 @@
   align-items: center;
   gap: 10px;
   min-width: 340px;
-  background: white;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 16px;
   padding: 12px 14px;
@@ -101,6 +101,7 @@
   outline: none;
   width: 100%;
   background: transparent;
+  color: var(--text);
   font: inherit;
 }
 
@@ -114,7 +115,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  background: white;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 14px;
   padding: 10px 12px;
@@ -130,7 +131,7 @@
 }
 
 .nurse-roaster-card {
-  background: white;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 24px;
   box-shadow: var(--shadow-sm);
@@ -164,14 +165,14 @@
 .nurse-roaster-table td {
   padding: 16px 18px;
   text-align: left;
-  border-top: 1px solid #edf3f7;
+  border-top: 1px solid var(--border);
   vertical-align: middle;
 }
 
 .nurse-roaster-table th {
   font-size: 0.9rem;
   color: var(--primary-dark);
-  background: #f9fcfe;
+  background: var(--surface-soft);
   white-space: nowrap;
 }
 
@@ -190,7 +191,7 @@
   width: 40px;
   height: 40px;
   border-radius: 999px;
-  background: linear-gradient(135deg, #dff1fb, #edf7fd);
+  background: linear-gradient(135deg, var(--surface-accent), var(--surface-accent-2));
   color: var(--primary-dark);
   font-weight: 800;
   display: flex;
@@ -260,7 +261,7 @@
   height: 34px;
   border-radius: 10px;
   border: 1px solid var(--border);
-  background: white;
+  background: var(--surface);
   color: var(--primary-dark);
   display: inline-flex;
   align-items: center;
@@ -270,7 +271,7 @@
 }
 
 .nurse-icon-btn:hover {
-  background: #f8fbfd;
+  background: var(--surface-soft);
 }
 
 .nurse-empty-state {

--- a/guardian-admin-dashboard/src/pages/NurseRosterPage.jsx
+++ b/guardian-admin-dashboard/src/pages/NurseRosterPage.jsx
@@ -1,11 +1,264 @@
+import { useMemo, useState } from "react";
+import {
+  Search,
+  Filter,
+  Plus,
+  CalendarDays,
+  Clock3,
+  UserRound,
+  Phone,
+  Mail,
+  ClipboardList,
+  Eye,
+  Pencil,
+} from "lucide-react";
+import "./NurseRoasterPage.css";
+
+const mockNurses = [
+  {
+    id: "NUR-001",
+    name: "Emily Stone",
+    email: "emily.stone@guardian.com",
+    phone: "+61 412 458 221",
+    shift: "Morning",
+    ward: "Ward A",
+    status: "On Duty",
+    assignedPatients: 5,
+    nextShift: "16 May 2026, 7:00 AM",
+  },
+  {
+    id: "NUR-002",
+    name: "Ava Lee",
+    email: "ava.lee@guardian.com",
+    phone: "+61 431 225 198",
+    shift: "Evening",
+    ward: "Ward B",
+    status: "Off Duty",
+    assignedPatients: 3,
+    nextShift: "16 May 2026, 3:00 PM",
+  },
+  {
+    id: "NUR-003",
+    name: "Nurse Emily",
+    email: "nurse.emily@guardian.com",
+    phone: "+61 490 785 640",
+    shift: "Night",
+    ward: "Ward C",
+    status: "On Leave",
+    assignedPatients: 0,
+    nextShift: "18 May 2026, 11:00 PM",
+  },
+  {
+    id: "NUR-004",
+    name: "Sophia Turner",
+    email: "sophia.turner@guardian.com",
+    phone: "+61 402 118 534",
+    shift: "Morning",
+    ward: "Ward A",
+    status: "On Duty",
+    assignedPatients: 4,
+    nextShift: "16 May 2026, 7:00 AM",
+  },
+];
+
 export default function NurseRoasterPage() {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedShift, setSelectedShift] = useState("All");
+  const [selectedStatus, setSelectedStatus] = useState("All");
+
+  const filteredNurses = useMemo(() => {
+    return mockNurses.filter((nurse) => {
+      const matchesSearch =
+        `${nurse.name} ${nurse.email} ${nurse.phone} ${nurse.ward}`.toLowerCase()
+          .includes(searchTerm.toLowerCase());
+
+      const matchesShift =
+        selectedShift === "All" || nurse.shift === selectedShift;
+
+      const matchesStatus =
+        selectedStatus === "All" || nurse.status === selectedStatus;
+
+      return matchesSearch && matchesShift && matchesStatus;
+    });
+  }, [searchTerm, selectedShift, selectedStatus]);
+
+  const onDutyCount = mockNurses.filter((nurse) => nurse.status === "On Duty").length;
+  const offDutyCount = mockNurses.filter((nurse) => nurse.status === "Off Duty").length;
+  const onLeaveCount = mockNurses.filter((nurse) => nurse.status === "On Leave").length;
+
+  const getStatusClass = (status) => {
+    if (status === "On Duty") return "nurse-status on-duty";
+    if (status === "Off Duty") return "nurse-status off-duty";
+    return "nurse-status on-leave";
+  };
+
   return (
-    <div className="panel">
-      <h3>Nurse Roster</h3>
-      <p>
-        This route is prepared for nurse roster related admin work. 
-        The team can continue implementation here using the shared shell layout.
-      </p>
-    </div>
+    <section className="nurse-roaster-page">
+      <div className="nurse-roaster-header">
+        <div>
+          <p className="nurse-roaster-eyebrow">Guardian Monitor Admin</p>
+          <h1>Nurse Roster</h1>
+          <p className="nurse-roaster-subtitle">
+            Review nurse availability, assigned workload, and shift details from the admin workspace.
+          </p>
+        </div>
+
+        <button className="nurse-primary-btn" type="button">
+          <Plus size={18} />
+          Add Nurse
+        </button>
+      </div>
+
+      <div className="nurse-summary-grid">
+        <div className="nurse-summary-card">
+          <UserRound size={18} />
+          <div>
+            <strong>{mockNurses.length}</strong>
+            <span>Total Nurses</span>
+          </div>
+        </div>
+
+        <div className="nurse-summary-card">
+          <Clock3 size={18} />
+          <div>
+            <strong>{onDutyCount}</strong>
+            <span>On Duty</span>
+          </div>
+        </div>
+
+        <div className="nurse-summary-card">
+          <CalendarDays size={18} />
+          <div>
+            <strong>{offDutyCount}</strong>
+            <span>Off Duty</span>
+          </div>
+        </div>
+
+        <div className="nurse-summary-card">
+          <ClipboardList size={18} />
+          <div>
+            <strong>{onLeaveCount}</strong>
+            <span>On Leave</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="nurse-toolbar">
+        <div className="nurse-search-box">
+          <Search size={16} />
+          <input
+            type="text"
+            placeholder="Search by nurse, ward, email, or phone..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+        </div>
+
+        <div className="nurse-filter-group">
+          <div className="nurse-filter-select">
+            <Filter size={16} />
+            <select
+              value={selectedShift}
+              onChange={(e) => setSelectedShift(e.target.value)}
+            >
+              <option value="All">All Shifts</option>
+              <option value="Morning">Morning</option>
+              <option value="Evening">Evening</option>
+              <option value="Night">Night</option>
+            </select>
+          </div>
+
+          <div className="nurse-filter-select">
+            <Filter size={16} />
+            <select
+              value={selectedStatus}
+              onChange={(e) => setSelectedStatus(e.target.value)}
+            >
+              <option value="All">All Status</option>
+              <option value="On Duty">On Duty</option>
+              <option value="Off Duty">Off Duty</option>
+              <option value="On Leave">On Leave</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div className="nurse-roaster-card">
+        <div className="nurse-roaster-card-header">
+          <h3>Roster List</h3>
+          <p>Current nurse records prepared in the admin dashboard interface.</p>
+        </div>
+
+        <div className="nurse-roaster-table-wrap">
+          <table className="nurse-roaster-table">
+            <thead>
+              <tr>
+                <th>Nurse</th>
+                <th>Contact</th>
+                <th>Shift</th>
+                <th>Ward</th>
+                <th>Patients</th>
+                <th>Status</th>
+                <th>Next Shift</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+
+            <tbody>
+              {filteredNurses.length > 0 ? (
+                filteredNurses.map((nurse) => (
+                  <tr key={nurse.id}>
+                    <td>
+                      <div className="nurse-name-cell">
+                        <div className="nurse-avatar">
+                          {nurse.name.charAt(0)}
+                        </div>
+                        <div>
+                          <strong>{nurse.name}</strong>
+                          <span>{nurse.id}</span>
+                        </div>
+                      </div>
+                    </td>
+
+                    <td>
+                      <div className="nurse-contact-cell">
+                        <span><Mail size={14} /> {nurse.email}</span>
+                        <span><Phone size={14} /> {nurse.phone}</span>
+                      </div>
+                    </td>
+
+                    <td>{nurse.shift}</td>
+                    <td>{nurse.ward}</td>
+                    <td>{nurse.assignedPatients}</td>
+                    <td>
+                      <span className={getStatusClass(nurse.status)}>
+                        {nurse.status}
+                      </span>
+                    </td>
+                    <td>{nurse.nextShift}</td>
+                    <td>
+                      <div className="nurse-actions">
+                        <button className="nurse-icon-btn" type="button">
+                          <Eye size={16} />
+                        </button>
+                        <button className="nurse-icon-btn" type="button">
+                          <Pencil size={16} />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan="8" className="nurse-empty-state">
+                    No nurse records found for the selected filters.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Overview
This PR adds the **Nurse Roaster** page UI to the Guardian Monitor Web Admin Dashboard.

## What was done
- Created the new **Nurse Roaster** page in the admin dashboard.
- Designed the page to align with the existing shared Guardian Monitor admin theme and blue-and-white UI direction.
- Added a structured nurse roster interface with:
  - page header
  - summary cards
  - search bar
  - filter controls
  - roster table
  - action buttons
- Used **mock nurse data** to establish the frontend structure and visual flow.
- Added a dedicated CSS file for the module to keep styling modular and maintainable.

## Note
This PR currently focuses on the **frontend UI only**.  
Backend integration for fetching real nurse records is intentionally kept for future scope. For now, mock data has been used so that the roster page structure, layout, and interaction design can be prepared in advance and integrated cleanly into the shared admin dashboard shell.

## Impact
This contribution expands the Web Admin Dashboard with another structured admin-facing module and prepares the Nurse Roaster page for future backend connectivity while maintaining consistency with the existing Guardian Monitor frontend design system.

## Page UI
<img width="1470" height="956" alt="Screenshot 2026-05-18 at 1 41 40 AM" src="https://github.com/user-attachments/assets/5f7e576a-50b0-43f1-b02f-b42ccdf8749c" />
