### PR TITLE
Add dashboard preferences customization

### DIFF
--- a/guardian-admin-dashboard/src/pages/DashboardHome.jsx
+++ b/guardian-admin-dashboard/src/pages/DashboardHome.jsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { motion } from "framer-motion";
 import StatCard from "../components/dashboard/StatCard";
 import { DASHBOARD_STATS } from "../utils/constants";
@@ -5,9 +6,21 @@ import { ArrowRight, Building2, Users, ShieldAlert, FileBarChart2 } from "lucide
 import { Link } from "react-router-dom";
 
 export default function DashboardHome() {
+  const dashboardPreferences = useMemo(() => {
+  const saved = localStorage.getItem("dashboardPreferences");
+
+  return saved
+    ? JSON.parse(saved)
+    : {
+        heroBanner: true,
+        statistics: true,
+        dashboardPanels: true,
+      };
+}, []);
   return (
     <div className="dashboard-home">
-      <motion.section
+      {dashboardPreferences.heroBanner && (
+       <motion.section
         className="hero-banner"
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
@@ -44,13 +57,17 @@ export default function DashboardHome() {
           </div>
         </div>
       </motion.section>
+      )}
 
-      <section className="stats-grid">
-        {DASHBOARD_STATS.map((item) => (
-          <StatCard key={item.title} {...item} />
-        ))}
-      </section>
+      {dashboardPreferences.statistics && (
+  <section className="stats-grid">
+    {DASHBOARD_STATS.map((item) => (
+      <StatCard key={item.title} {...item} />
+    ))}
+  </section>
+)}
 
+      {dashboardPreferences.dashboardPanels && (
       <section className="dashboard-panels">
         <motion.article
           className="panel large"
@@ -98,6 +115,7 @@ export default function DashboardHome() {
           </div>
         </motion.article>
       </section>
+      )}
     </div>
   );
 }

--- a/guardian-admin-dashboard/src/pages/SettingsPage.jsx
+++ b/guardian-admin-dashboard/src/pages/SettingsPage.jsx
@@ -31,12 +31,43 @@ export default function SettingsPage() {
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
   const [feedback, setFeedback] = useState("");
+  
+  const [dashboardPreferencesOpen, setDashboardPreferencesOpen] =
+  useState(false);
+
+const [dashboardPreferences, setDashboardPreferences] = useState(() => {
+  const savedPreferences = localStorage.getItem("dashboardPreferences");
+
+  return savedPreferences
+    ? JSON.parse(savedPreferences)
+    : {
+        heroBanner: true,
+        statistics: true,
+        dashboardPanels: true,
+      };
+});
 
   const toggleDarkMode = () => {
     const next = !darkMode;
     setDarkMode(next);
     document.body.classList.toggle("dark-theme", next);
   };
+
+  const toggleDashboardPreference = (preferenceName) => {
+  setDashboardPreferences((previousPreferences) => ({
+    ...previousPreferences,
+    [preferenceName]: !previousPreferences[preferenceName],
+  }));
+};
+
+const saveDashboardPreferences = () => {
+  localStorage.setItem(
+    "dashboardPreferences",
+    JSON.stringify(dashboardPreferences)
+  );
+
+  setDashboardPreferencesOpen(false);
+};
 
   const feedbackWordCount = useMemo(() => {
     return feedback.trim() ? feedback.trim().split(/\s+/).length : 0;
@@ -146,7 +177,11 @@ export default function SettingsPage() {
                 <ChevronRight size={16} />
               </button>
 
-              <button type="button" className="settings-action-tile">
+              <button
+                type="button"
+                className="settings-action-tile"
+                onClick={() => setDashboardPreferencesOpen(true)}
+                >
                 <div className="settings-action-left">
                   <MonitorCog size={17} />
                   <span>Dashboard Preferences</span>
@@ -208,7 +243,100 @@ export default function SettingsPage() {
         </div>
       </div>
 
-      {notificationsOpen && (
+      
+        {dashboardPreferencesOpen && (
+  <div className="settings-modal-backdrop">
+    <div className="settings-modal small-modal">
+      <div className="settings-modal-top">
+        <div>
+          <p className="settings-modal-eyebrow">Dashboard Preferences</p>
+          <h3>Customize Dashboard</h3>
+        </div>
+
+        <button
+          type="button"
+          className="settings-modal-close"
+          onClick={() => setDashboardPreferencesOpen(false)}
+          aria-label="Close dashboard preferences"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      <div className="settings-stack">
+        <div className="settings-row">
+          <div className="settings-row-copy">
+            <strong>Welcome Banner</strong>
+            <p>Show the welcome message and quick navigation links.</p>
+          </div>
+
+          <button
+            type="button"
+            className={`mini-toggle ${
+              dashboardPreferences.heroBanner ? "active" : ""
+            }`}
+            onClick={() => toggleDashboardPreference("heroBanner")}
+          >
+            <span />
+          </button>
+        </div>
+
+        <div className="settings-row">
+          <div className="settings-row-copy">
+            <strong>Statistics Cards</strong>
+            <p>Show the summary statistics on the main dashboard.</p>
+          </div>
+
+          <button
+            type="button"
+            className={`mini-toggle ${
+              dashboardPreferences.statistics ? "active" : ""
+            }`}
+            onClick={() => toggleDashboardPreference("statistics")}
+          >
+            <span />
+          </button>
+        </div>
+
+        <div className="settings-row">
+          <div className="settings-row-copy">
+            <strong>Dashboard Panels</strong>
+            <p>Show progress information and upcoming modules.</p>
+          </div>
+
+          <button
+            type="button"
+            className={`mini-toggle ${
+              dashboardPreferences.dashboardPanels ? "active" : ""
+            }`}
+            onClick={() => toggleDashboardPreference("dashboardPanels")}
+          >
+            <span />
+          </button>
+        </div>
+      </div>
+
+      <div className="settings-modal-actions">
+        <button
+          type="button"
+          className="settings-secondary-btn"
+          onClick={() => setDashboardPreferencesOpen(false)}
+        >
+          Cancel
+        </button>
+
+        <button
+          type="button"
+          className="settings-primary-btn"
+          onClick={saveDashboardPreferences}
+        >
+          Save Preferences
+        </button>
+      </div>
+    </div>
+  </div>
+)}
+{notificationsOpen && (
         <div className="settings-modal-backdrop">
           <div className="settings-modal small-modal">
             <div className="settings-modal-top">


### PR DESCRIPTION
## Description

Implemented dashboard preferences customization for the Guardian Admin Dashboard.

### Changes
- Added Dashboard Preferences modal in Settings.
- Added toggles for:
  - Welcome Banner
  - Statistics Cards
  - Dashboard Panels
- Saved preferences using localStorage.
- Updated DashboardHome to show/hide sections based on saved preferences.
- Preferences persist after refreshing the page.

### Testing
- Tested locally.
- Verified each toggle updates the dashboard correctly.
- Verified preferences remain after page refresh.